### PR TITLE
Keep renamed files in the original folder by using tp.file.rename

### DIFF
--- a/templates/goodreads.md
+++ b/templates/goodreads.md
@@ -46,5 +46,5 @@ let filename = title
 // Remove prohibited characters
 filename = filename.replace(/[/\:*?<>|""]/g, "")
 // Rename a note
-await tp.file.move(filename)
+await tp.file.rename(filename)
 -%>

--- a/templates/imdb.md
+++ b/templates/imdb.md
@@ -83,5 +83,5 @@ let filename = title
 // Remove prohibited characters
 filename = filename.replace(/[/\:*?<>|""]/g, "")
 // Rename a note
-await tp.file.move(filename)
+await tp.file.rename(filename)
 -%>

--- a/templates/letterboxd.md
+++ b/templates/letterboxd.md
@@ -110,5 +110,5 @@ let filename = title
 // Remove prohibited characters
 filename = filename.replace(/[/\:*?<>|""]/g, "")
 // Rename a note
-await tp.file.move(filename)
+await tp.file.rename(filename)
 -%>

--- a/templates/odysee.md
+++ b/templates/odysee.md
@@ -38,5 +38,5 @@ let filename = title
 // Remove prohibited characters
 filename = filename.replace(/[/\:*?<>|""]/g, "")
 // Rename a note
-await tp.file.move(filename)
+await tp.file.rename(filename)
 -%>

--- a/templates/youtube.md
+++ b/templates/youtube.md
@@ -42,5 +42,5 @@ let filename = title
 // Remove prohibited characters
 filename = filename.replace(/[/\:*?<>|""]/g, "")
 // Rename a note
-await tp.file.move(filename)
+await tp.file.rename(filename)
 -%>


### PR DESCRIPTION
`tp.file.move` unintentionally relocates files to the root of the vault during rename.
Replacing it with `tp.file.rename` keeps the note in the same folder instead of moving it, preserving either its current folder or the default folder configured for new notes in Obsidian.